### PR TITLE
`make chat` initial implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 run:
 	PYTHONPATH='..' python src/main.py
 
+chat:
+	PYTHONPATH='..' python src/chat.py
+
 test:
 	rm -f .test.db
 	MIMIBOT_TEST=1 PYTHONPATH='..' nosetests --nocapture

--- a/src/chat.py
+++ b/src/chat.py
@@ -1,0 +1,22 @@
+from mimibot.src.registry import COMMANDS
+
+
+def handle_message(message):
+    """
+    Sees if the message provokes any responses from the bot.
+    """
+    responses = [response for response in
+                 [command.get_response(message, "channel_foo") for
+                  command in COMMANDS]
+                 if response]
+    for response in responses:
+        print response
+    print ""
+
+
+if __name__ == "__main__":
+    print "Chat with mimibot below"
+    print ""
+    while True:
+        message = str(raw_input("@mimibot "))
+        handle_message(message)


### PR DESCRIPTION
I just wanted something to be able to quickly and manually "integration test" the code that's written.

`make chat` will now read from stdin and have mimibot respond however it feels is appropriate

### Testing
```bash
zac@macbook ~/personal_projects/mimibot $ make chat
PYTHONPATH='..' python src/chat.py
Chat with mimibot below

@mimibot help
Here is a list of commands -- for usage instructions try 'help <command>'

*add* - adds one or more number(s) together
*get* - gets a key from the db
*linkme* - Display a list of helpful links for mimi
*set* - sets a key in the db
```