### PR TITLE
Add translate command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ run:
 	PYTHONPATH='..' python src/main.py
 
 chat:
-	PYTHONPATH='..' python src/chat.py
+	PYTHONIOENCODING=utf-8 PYTHONPATH='..' python src/chat.py
 
 test:
 	rm -f .test.db

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ slackclient==1.0.5
 websocket-client==0.40.0
 pickledb==0.6.2
 flake8==3.3.0
+vcrpy==1.11.0

--- a/src/commands/translate.py
+++ b/src/commands/translate.py
@@ -1,0 +1,29 @@
+import os
+import requests
+import json
+
+from mimibot.src.constants import GOOGLE_TRANSLATE_URL
+
+
+class Translate(object):
+    def __init__(self):
+        self.command = "translate"
+        self.help_text = "translates text from english to german"
+        self.usage = "translate Hello, I am a human."
+
+    def get_response(self, command, user=None, channel=None):
+        if command.startswith(self.command):
+            return self.translate(" ".join(command.split(" ")[1:]))
+
+    def translate(self, query):
+        parameters = {
+            'key': os.environ.get('GOOGLE_TRANSLATE_API_KEY'),
+            'q': query,
+            'source': 'en',
+            'target': 'de',
+        }
+        response = requests.get(GOOGLE_TRANSLATE_URL.format(**parameters))
+        translation = json.loads(response.content)
+        translated = (
+            translation['data']['translations'][0]['translatedText'])
+        return translated

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,3 +5,5 @@ if test:
     DB_PATH = '/.test.db'
 else:
     DB_PATH = '/db/pickle.db'
+
+GOOGLE_TRANSLATE_URL = "https://translation.googleapis.com/language/translate/v2?key={key}&q={q}&source={source}&target={target}"  # noqa

--- a/src/registry.py
+++ b/src/registry.py
@@ -3,6 +3,7 @@ from mimibot.src.commands.get import Get
 from mimibot.src.commands.help import Help
 from mimibot.src.commands.linkme import Linkme
 from mimibot.src.commands.set import Set
+from mimibot.src.commands.translate import Translate
 
 COMMANDS = [
     Add(),
@@ -10,4 +11,5 @@ COMMANDS = [
     Help(),
     Linkme(),
     Set(),
+    Translate(),
 ]

--- a/tests/cassettes/test_translates_sentences
+++ b/tests/cassettes/test_translates_sentences
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://translation.googleapis.com/language/translate/v2?q=Hello%2C+I+am+a+robot.&source=en&target=de
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/6vmUlBQSkksSVSyUqgGsoG8kqLEvOKcxJLM/LxioGg0WFQBKouiIjUlJLWiBKhG
+        ySMxJydfRyEzOUMhKTNPIRWIg/KT8ktSi/SUoPpqwXQsF4hVywUALfXkNngAAAA=
+    headers:
+      alt-svc: ['quic=":443"; ma=2592000; v="37,36,35"']
+      cache-control: [private]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=UTF-8]
+      date: ['Tue, 02 May 2017 14:28:15 GMT']
+      server: [ESF]
+      vary: [Origin, X-Origin, Referer]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/cassettes/test_translates_words
+++ b/tests/cassettes/test_translates_words
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://translation.googleapis.com/language/translate/v2?q=two&source=en&target=de
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/6vmUlBQSkksSVSyUqgGsoG8kqLEvOKcxJLM/LxioGg0WFQBKouiIjUlJLWiBKhG
+        qao8NVMJqqAWTMdygVi1XADR2atrYQAAAA==
+    headers:
+      alt-svc: ['quic=":443"; ma=2592000; v="37,36,35"']
+      cache-control: [private]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=UTF-8]
+      date: ['Tue, 02 May 2017 14:28:16 GMT']
+      server: [ESF]
+      vary: [Origin, X-Origin, Referer]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+
+import vcr
+
+from mimibot.src.commands.translate import Translate
+
+
+class TestAdd(TestCase):
+    def setUp(self):
+        self.translate_command = Translate()
+
+    @vcr.use_cassette(
+        'tests/cassettes/test_translates_words',
+        filter_query_parameters=['key'])
+    def test_translates_words(self):
+        response = self.translate_command.get_response("translate two")
+        self.assertEqual(response, "zwei")
+
+    @vcr.use_cassette(
+        'tests/cassettes/test_translates_sentences',
+        filter_query_parameters=['key'])
+    def test_translates_sentences(self):
+        response = self.translate_command.get_response(
+            "translate Hello, I am a robot.")
+        self.assertEqual(response, "Hallo, ich bin ein Roboter.")


### PR DESCRIPTION
This commands translates text from english to german. I also plan to add "ubersetzen" as well (for translating german to english)

### Testing

```shell
zac@macbook ~/personal_projects/mimibot $ make chat
PYTHONIOENCODING=utf-8 PYTHONPATH='..' python src/chat.py
Chat with mimibot below

@mimibot translate hello world
Hallo Welt
```

This also includes adding the `vcrpy` library for playing back network requests during tests.