### PR TITLE
Add ubersetzen command

### DIFF
--- a/src/commands/translate.py
+++ b/src/commands/translate.py
@@ -1,8 +1,4 @@
-import os
-import requests
-import json
-
-from mimibot.src.constants import GOOGLE_TRANSLATE_URL
+from mimibot.src.utils import translate
 
 
 class Translate(object):
@@ -13,17 +9,4 @@ class Translate(object):
 
     def get_response(self, command, user=None, channel=None):
         if command.startswith(self.command):
-            return self.translate(" ".join(command.split(" ")[1:]))
-
-    def translate(self, query):
-        parameters = {
-            'key': os.environ.get('GOOGLE_TRANSLATE_API_KEY'),
-            'q': query,
-            'source': 'en',
-            'target': 'de',
-        }
-        response = requests.get(GOOGLE_TRANSLATE_URL.format(**parameters))
-        translation = json.loads(response.content)
-        translated = (
-            translation['data']['translations'][0]['translatedText'])
-        return translated
+            return translate(" ".join(command.split(" ")[1:]), 'en', 'de')

--- a/src/commands/ubersetzen.py
+++ b/src/commands/ubersetzen.py
@@ -1,0 +1,12 @@
+from mimibot.src.utils import translate
+
+
+class Ubersetzen(object):
+    def __init__(self):
+        self.command = "ubersetzen"
+        self.help_text = "translates text from german to english"
+        self.usage = "ubersetzen Hello, I am a cat."
+
+    def get_response(self, command, user=None, channel=None):
+        if command.startswith(self.command):
+            return translate(" ".join(command.split(" ")[1:]), 'de', 'en')

--- a/src/registry.py
+++ b/src/registry.py
@@ -4,6 +4,7 @@ from mimibot.src.commands.help import Help
 from mimibot.src.commands.linkme import Linkme
 from mimibot.src.commands.set import Set
 from mimibot.src.commands.translate import Translate
+from mimibot.src.commands.ubersetzen import Ubersetzen
 
 COMMANDS = [
     Add(),
@@ -12,4 +13,5 @@ COMMANDS = [
     Linkme(),
     Set(),
     Translate(),
+    Ubersetzen(),
 ]

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,19 @@
+import os
+import requests
+import json
+
+from mimibot.src.constants import GOOGLE_TRANSLATE_URL
+
+
+def translate(query, source, target):
+    parameters = {
+        'key': os.environ.get('GOOGLE_TRANSLATE_API_KEY'),
+        'q': query,
+        'source': source,
+        'target': target,
+    }
+    response = requests.get(GOOGLE_TRANSLATE_URL.format(**parameters))
+    translation = json.loads(response.content)
+    translated = (
+        translation['data']['translations'][0]['translatedText'])
+    return translated

--- a/tests/cassettes/test_ubersetzen_many_words
+++ b/tests/cassettes/test_ubersetzen_many_words
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://translation.googleapis.com/language/translate/v2?q=Ich+bin+eine+Katze&source=de&target=en
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/6vmUlBQSkksSVSyUqgGsoG8kqLEvOKcxJLM/LxioGg0WFQBKouiIjUlJLWiBKhG
+        yVMhMVchUSE5sUQJqqwWTMdygVi1XACpYRP1ZwAAAA==
+    headers:
+      alt-svc: ['quic=":443"; ma=2592000; v="37,36,35"']
+      cache-control: [private]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=UTF-8]
+      date: ['Tue, 02 May 2017 15:04:18 GMT']
+      server: [ESF]
+      vary: [Origin, X-Origin, Referer]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/cassettes/test_ubersetzen_one_word
+++ b/tests/cassettes/test_ubersetzen_one_word
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://translation.googleapis.com/language/translate/v2?q=Katze&source=de&target=en
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/6vmUlBQSkksSVSyUqgGsoG8kqLEvOKcxJLM/LxioGg0WFQBKouiIjUlJLWiBKhG
+        KTmxRAkqXwumY7lArFouAO1hIupgAAAA
+    headers:
+      alt-svc: ['quic=":443"; ma=2592000; v="37,36,35"']
+      cache-control: [private]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=UTF-8]
+      date: ['Tue, 02 May 2017 15:04:18 GMT']
+      server: [ESF]
+      vary: [Origin, X-Origin, Referer]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_ubersetzen.py
+++ b/tests/test_ubersetzen.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+
+import vcr
+
+from mimibot.src.commands.ubersetzen import Ubersetzen
+
+
+class TestUbersetzen(TestCase):
+    def setUp(self):
+        self.ubersetzen_command = Ubersetzen()
+
+    @vcr.use_cassette(
+        'tests/cassettes/test_ubersetzen_one_word',
+        filter_query_parameters=['key'])
+    def test_ubersetzen_one_word(self):
+        response = self.ubersetzen_command.get_response("ubersetzen Katze")
+        self.assertEqual(response, "cat")
+
+    @vcr.use_cassette(
+        'tests/cassettes/test_ubersetzen_many_words',
+        filter_query_parameters=['key'])
+    def test_ubersetzen_many_words(self):
+        response = self.ubersetzen_command.get_response(
+            "ubersetzen Ich bin eine Katze")
+        self.assertEqual(response, "I am a cat")


### PR DESCRIPTION
This adds the `ubersetzen` command. It's not `übersetzen` because I have a terrible time with getting unicode to work in the 1,000 different environments in which it'd need to be handled.

This also takes the `translate` function and throws it in `utils`